### PR TITLE
6.13 Improvement. Add default reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# All default reviers from project  epambrest /capacity.
+*	@SergeyMokin @Artem-Halvita @desenzo @sub13 @aparkhots @alehkahnovich @Y-floryanovich


### PR DESCRIPTION
I added file CODEOWNERS which need to add automatically all reviewers to pull request. When you will create pull request, all reviewers will be added.
You can read about this feature on this sites:
1) https://codex.so/github-codeowners;
2) https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners;
if you have some offers, please write messages to this pull request
