### PR TITLE
6.15 Bug. Submit editing without changes brake application.

### DIFF
--- a/src/Teams.Web/Controllers/ManageTasksController.cs
+++ b/src/Teams.Web/Controllers/ManageTasksController.cs
@@ -166,6 +166,18 @@ namespace Teams.Web.Controllers
                     SprintId = taskViewModel.TaskSprintId,
                     MemberId = taskViewModel.TaskMemberId
                 };
+
+                var currentTask = await _manageTasksService.GetTaskByIdAsync(taskViewModel.TaskId);
+
+                if (currentTask.Name== taskViewModel.TaskName && 
+                    currentTask.Link == taskViewModel.TaskLink &&
+                    currentTask.StoryPoints == taskViewModel.TaskStoryPoints&&
+                    currentTask.MemberId== taskViewModel.TaskMemberId
+                    )
+                {
+                    return RedirectToAction("EditTask", new { teamId = taskViewModel.TeamId, taskId = taskViewModel.TaskId, errorMessage = _localizer["HasntAnyChange"] });
+                }
+
                 var result = await EditTaskAsync(task);
 
                 if (result) return RedirectToAction("AllTasksForTeam", new { teamId = taskViewModel.TeamId });

--- a/src/Teams.Web/Resources/Controllers/ManageTasksController.en.resx
+++ b/src/Teams.Web/Resources/Controllers/ManageTasksController.en.resx
@@ -123,6 +123,9 @@
   <data name="Error" xml:space="preserve">
     <value>Ooops... Something went wrong!</value>
   </data>
+  <data name="HasntAnyChange" xml:space="preserve">
+    <value>You hasn't change your Task</value>
+  </data>
   <data name="LinkFieldError" xml:space="preserve">
     <value>Incorrect link!</value>
   </data>

--- a/src/Teams.Web/Resources/Controllers/ManageTasksController.ru.resx
+++ b/src/Teams.Web/Resources/Controllers/ManageTasksController.ru.resx
@@ -124,7 +124,7 @@
     <value>Упс... Похоже что-то пошло не так</value>
   </data>
   <data name="HasntAnyChange" xml:space="preserve">
-    <value>Вы ничего не изменили в своёй задаче</value>
+    <value>Вы ничего не изменили в своей задаче</value>
   </data>
   <data name="LinkFieldError" xml:space="preserve">
     <value>Неправильная ссылка!</value>

--- a/src/Teams.Web/Resources/Controllers/ManageTasksController.ru.resx
+++ b/src/Teams.Web/Resources/Controllers/ManageTasksController.ru.resx
@@ -123,6 +123,9 @@
   <data name="Error" xml:space="preserve">
     <value>Упс... Похоже что-то пошло не так</value>
   </data>
+  <data name="HasntAnyChange" xml:space="preserve">
+    <value>Вы ничего не изменили в своёй задаче</value>
+  </data>
   <data name="LinkFieldError" xml:space="preserve">
     <value>Неправильная ссылка!</value>
   </data>


### PR DESCRIPTION
Submit editing without changes brake application. someone fixed it in the sprint, but I fixed it in the task too
![image](https://user-images.githubusercontent.com/46692099/107223000-b2714000-6a26-11eb-8c45-5826d739e685.png)
![image](https://user-images.githubusercontent.com/46692099/107223026-bac97b00-6a26-11eb-90e0-ed08d2813c05.png)

I found a new bug if we choose to change the task, then the current user will not be selected in it and we will need to select him again.

![image](https://user-images.githubusercontent.com/46692099/107223370-2ad80100-6a27-11eb-9f1d-dcbd79be12e1.png)
