### PR TITLE
7.17 Bug. which crash AllsprintsView

### DIFF
--- a/src/Teams.Web/Controllers/ManageSprintsController.cs
+++ b/src/Teams.Web/Controllers/ManageSprintsController.cs
@@ -81,7 +81,7 @@ namespace Teams.Web.Controllers
             }
             ));
 
-            if (sprintViewModel.Sprints[1].Status == PossibleStatuses.ActiveStatus)
+            if (sprintViewModel.Sprints.Count > 1 && sprintViewModel.Sprints[1].Status == PossibleStatuses.ActiveStatus)
             {
                 var swapElem = sprintViewModel.Sprints[0];
                 sprintViewModel.Sprints[0] = sprintViewModel.Sprints[1];


### PR DESCRIPTION
i fixed bug which was breaking our AllsprintsView. This bug was happening when we wanted to check sprints in new Team without sprints. You can see this bug on screenshoot
![изображение](https://user-images.githubusercontent.com/47415747/110761501-db246980-8260-11eb-8724-769d4381c9f2.png)
